### PR TITLE
Nitpicking

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 sebastianludwig
+Copyright (c) 2015 Sebastian Ludwig
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -14,11 +14,20 @@
 [formatter addFormat:@"R" forLast:7 unit:SLTimeUnitDays];
 formatter.defaultFormat = @"{yMd}";
 
-result = [self.formatter stringForTimeIntervalFromDate:minutesAgo toReferenceDate:now];     // 42 minutes ago
-result = [self.formatter stringForTimeIntervalFromDate:earlierToday toReferenceDate:now];   // 13:37
-result = [self.formatter stringForTimeIntervalFromDate:yesterday toReferenceDate:now];      // yesterday
-result = [self.formatter stringForTimeIntervalFromDate:threeDaysAgo toReferenceDate:now];   // 3 days ago
-result = [self.formatter stringForTimeIntervalFromDate:longAgo toReferenceDate:now];        // 2/11/2015
+[self.formatter stringForTimeIntervalFromDate:minutesAgo toReferenceDate:now];
+// = 42 minutes ago
+
+[self.formatter stringForTimeIntervalFromDate:earlierToday toReferenceDate:now];
+// = 13:37
+
+[self.formatter stringForTimeIntervalFromDate:yesterday toReferenceDate:now];
+// = yesterday
+
+[self.formatter stringForTimeIntervalFromDate:threeDaysAgo toReferenceDate:now];
+// = 3 days ago
+
+[self.formatter stringForTimeIntervalFromDate:longAgo toReferenceDate:now];
+// = 2/11/2015
 ```
 
 ## String generation

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ result = [self.formatter stringForTimeIntervalFromDate:longAgo toReferenceDate:n
 
 - `(NSString *)stringForTimeIntervalFromDate:(NSDate *)date toReferenceDate:(NSDate *)referenceDate`
 	
-	Formats the given date. For relative and idiomatic formats the time difference between the given date and the reference date is used.
+	Formats the given date. For relative and idiomatic formats, the time difference between the given date and the reference date is used.
 
 - `(NSString *)stringForTimeIntervalFromDate:(NSDate *)date`
 
@@ -39,9 +39,9 @@ result = [self.formatter stringForTimeIntervalFromDate:longAgo toReferenceDate:n
 
 - `I` for idiomatic expressions like "yesterday" or "next month"
 - `R` for relative expressions like "2 weeks ago" or "1 day from now"
-- `RRRR` repeat up to 7 `R` to specify the number of significant units.`RR` yields expressions like "2 days 13 hours ago"
+- `RRRR` repeat up to 7 `R` to specify the number of significant units. `RR` yields expressions like "2 days 13 hours ago"
 - `~R` prepend `~` to any `R` format to add an approximate qualifier as in "about 4 hours ago", if the time difference isn't exact
-- `{HH:mm}` for usual date formatting. You can use anything you'd normally set on `[NSDateFormatter -setDateFormat:]`. Unlike `I` and `R` these patterns need to be wrapped in curly braces.
+- `{HH:mm}` for usual date formatting. You can use anything you'd normally set on `[NSDateFormatter -setDateFormat:]`. Unlike `I` and `R`, these patterns need to be wrapped in curly braces.
 - `{hm}` for date formatting templates. Date formatting patterns that only consists of placeholders (no colons, spaces etc) will be used as template. Templates are converted to date formats using `[NSDateFormatter
 +dateFormatFromTemplate:options:locale:]` with regard to the set locale.
 
@@ -51,11 +51,11 @@ Formats can be added using one of four flavours.
 
 1. `addFormat:(NSString *)format forTimeInterval:(NSTimeInterval)timeInterval`
 	
-	Adds a format to be used if the difference between a date and the reference date lays in the given time interval.
+	Adds a format to be used if the difference between a date and the reference date lies in the given time interval.
 
 2. `addFormat:(NSString *)format for:(SLTimeUnit)unit`
 
-	 Adds a fromat to be used for a specific time unit. The time unit needs to be a relative time unit like `SLTimeUnitToday`, `SLTimeUnitSameWeek` or `SLTimeNextYear`. Check out the header for a complete list.
+	 Adds a format to be used for a specific time unit. The time unit needs to be a relative time unit like `SLTimeUnitToday`, `SLTimeUnitSameWeek` or `SLTimeNextYear`. Check out the header for a complete list.
 
 3. `addFormat:(NSString *)format forLast:(NSUInteger)count unit:(SLTimeUnit)unit`
 
@@ -63,12 +63,12 @@ Formats can be added using one of four flavours.
 
 4. `addFormat:(NSString *)format forNext:(NSUInteger)count unit:(SLTimeUnit)unit`
 
-	Same as 3. but for a time span in the future.
+	Same as 3., but for a time span in the future.
 
 
 The formats are checked in the same order they are added. If two formats satisfy the condition for a date, the date will be formatted with the one added first. Only one format will be applied.
 
-If no format matches the condition for a given date a default format will be used (if specified).
+If no format matches the condition for a given date, a default format will be used (if specified).
 
 
 ## Examples
@@ -86,7 +86,7 @@ pod "SLConditionalDateFormatter"
 
 ## Alternatives
 
-Based on @mattt's work on [mattt/FormatterKit] and everybody who contributed there. Go check it out, maybe it better suits your needs.
+Based on @mattt's work on [FormatterKit](https://github.com/mattt/FormatterKit) and everybody who contributed there. Go check it out, maybe it better suits your needs.
 
 ## Author
 


### PR DESCRIPTION
I've tried to limit this PR to the things that I feel are definitely better: Fixing typos, more consistent formatting, a bit of consistency here and there, not being too clever with the `^` operator :)

I'm not sure if making the string helpers class methods was the right call, though. Feel free to just cherry-pick some bits here and there...

Some other suggestions:
1. I don't like how `setTimeZone:` magically sets `self.calendar.timeZone` as well, same for the locale. Why not just use the calendar's `timeZone`/`locale`? That way you only have to encode a single object, and data cannot get out of sync. As a compromise, you could offer the `timeZone`/`locale` properties but route them through to the `calendar`'s properties (no backing ivar)
2. I'd start the instance variables with an _underscore to be consistent with auto-generated `@property` ivars
3. Not sure what the _Pods symlink is doing in the root directory :)
4. `.gitkeep` in `Classes` doesn't serve a purpose since the directory is non-empty
5. I wouldn't use CocoaPods for the example, just add the files in `Classes` manually and you can keep ~10 files out of git (also - I see an warning that frameworks only work on iOS 8 - do you use frameworks but set an iOS 7 deployment target?)
6. I think the backwards-compatible constants for time units are over-engineered; can you even submit iOS apps with the old SDKs that don't support the new constants? => I'd just use the new constants instead...
7. Should it default to `NSLocale.currentLocale` (as it does right now) or to `NSBundle.mainBundle.preferredLocalizations.firstObject` (or maybe not the `mainBundle`, but the resource bundle)? Honest question, I have no idea.
8. File organisation nitpick: I like having the `Classes` folder in the root of the git repository. Flatten all the things 💪🏽
9. From a quick glance, the `NSCoding` impl only seems to encode/decode all the properties, not the ivars?
